### PR TITLE
Marshmallow dropped support for py2 in marshmallow 3. as the package …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ ipaddress==1.0.23
 itsdangerous==1.1.0
 Jinja2==2.11.0
 MarkupSafe==1.1.1
-marshmallow==3.3.0
+marshmallow==2.21.0
 nose==1.3.7
 pycparser==2.19
 pycrypto==2.6.1


### PR DESCRIPTION
…was built on 2.7, using the latest version introduces some validation errors.